### PR TITLE
element.rs: use zero_advance for gutter dimensions

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5924,6 +5924,11 @@ impl Element for EditorElement {
                         .advance(font_id, font_size, 'm')
                         .unwrap()
                         .width;
+                    let zero_advance = cx
+                        .text_system()
+                        .advance(font_id, font_size, '0')
+                        .unwrap()
+                        .width;
 
                     let letter_size = size(em_width, line_height);
 
@@ -5931,7 +5936,7 @@ impl Element for EditorElement {
                         font_id,
                         font_size,
                         em_width,
-                        em_advance,
+                        zero_advance,
                         self.max_line_number_width(&snapshot, cx),
                         cx,
                     );
@@ -7407,13 +7412,18 @@ fn compute_auto_height_layout(
         .advance(font_id, font_size, 'm')
         .unwrap()
         .width;
+    let zero_advance = cx
+        .text_system()
+        .advance(font_id, font_size, '0')
+        .unwrap()
+        .width;
 
     let mut snapshot = editor.snapshot(cx);
     let gutter_dimensions = snapshot.gutter_dimensions(
         font_id,
         font_size,
         em_width,
-        em_advance,
+        zero_advance,
         max_line_number_width,
         cx,
     );


### PR DESCRIPTION
[Addresses #21860](https://github.com/zed-industries/zed/issues/21860)

Hey @matj1!
I hesitated to bother Zed maintainers with my crude changes. But this _might_ be helpful on your quest for making that gutter slimmer.
Those seem to be the only functions setting the `gutter_dimensions` in this file.

Here's the definition of that `snapshot.gutter_dimensions` function:
https://github.com/zed-industries/zed/blob/f6dabadaf79bd29c89c8d55a1e9f1d33236f736e/crates/editor/src/editor.rs#L13929

I think that only `em_advance` argument has to be tweaked, because that's the only one that is being used for line numbers width calculation.
The `em_width` argument is used for paddings needed for stuff like code actions, folding, runnables and git gutter.